### PR TITLE
[FEAT] 페이지네이션 파라미터 리졸버 

### DIFF
--- a/src/main/java/com/followMe/common/autoconfigure/CommonWebAutoConfiguration.java
+++ b/src/main/java/com/followMe/common/autoconfigure/CommonWebAutoConfiguration.java
@@ -1,23 +1,36 @@
 package com.followMe.common.autoconfigure;
 
+import com.followMe.common.pagination.CursorRequestArgumentResolver;
+import com.followMe.common.pagination.PageRequestArgumentResolver;
 import com.followMe.common.web.GlobalExceptionHandler;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 /**
  * Web MVC 환경에서 공통 빈 자동 등록.
  *
  * <p>{@link GlobalExceptionHandler} 를 직접 정의한 서비스에서는 이 설정이 적용되지 않습니다.
+ * <p>{@link PageRequestArgumentResolver} 는 항상 등록됩니다.
  */
 @AutoConfiguration
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
-public class CommonWebAutoConfiguration {
+public class CommonWebAutoConfiguration implements WebMvcConfigurer {
 
     @Bean
     @ConditionalOnMissingBean(GlobalExceptionHandler.class)
     public GlobalExceptionHandler globalExceptionHandler() {
         return new GlobalExceptionHandler();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new PageRequestArgumentResolver());
+        resolvers.add(new CursorRequestArgumentResolver());
     }
 }

--- a/src/main/java/com/followMe/common/pagination/CursorRequest.java
+++ b/src/main/java/com/followMe/common/pagination/CursorRequest.java
@@ -1,0 +1,38 @@
+package com.followMe.common.pagination;
+
+import lombok.Getter;
+
+/**
+ * 커서 기반 페이지 요청 DTO.
+ *
+ * <p>커서가 {@code null}이면 첫 페이지를 의미합니다.
+ * 허용되지 않은 size 값은 {@link PageRequest#DEFAULT_SIZE}(10)으로 대체됩니다.
+ *
+ * <pre>{@code
+ * @GetMapping("/feeds")
+ * public ApiResponse<CursorResponse<FeedResponse>> list(CursorRequest cursorRequest) {
+ *     return ApiResponse.success(feedService.list(cursorRequest));
+ * }
+ * }</pre>
+ *
+ * @see CursorResponse
+ */
+@Getter
+public class CursorRequest {
+
+    private final String cursor; // null이면 첫 페이지
+    private final int size;
+
+    private CursorRequest(String cursor, int size) {
+        this.cursor = cursor;
+        this.size = PageRequest.ALLOWED_SIZES.contains(size) ? size : PageRequest.DEFAULT_SIZE;
+    }
+
+    public static CursorRequest of(String cursor, int size) {
+        return new CursorRequest(cursor, size);
+    }
+
+    public boolean isFirst() {
+        return cursor == null;
+    }
+}

--- a/src/main/java/com/followMe/common/pagination/CursorRequestArgumentResolver.java
+++ b/src/main/java/com/followMe/common/pagination/CursorRequestArgumentResolver.java
@@ -1,0 +1,50 @@
+package com.followMe.common.pagination;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 컨트롤러 파라미터로 선언된 {@link CursorRequest}를 쿼리 파라미터에서 자동 바인딩.
+ *
+ * <p>{@code ?cursor=xxx&size=10} 형태로 요청하면 {@link CursorRequest}로 변환됩니다.
+ * {@code cursor} 파라미터가 없으면 첫 페이지({@code null})로 처리됩니다.
+ *
+ * <pre>{@code
+ * @GetMapping("/feeds")
+ * public ApiResponse<CursorResponse<FeedResponse>> list(CursorRequest cursorRequest) {
+ *     return ApiResponse.success(feedService.list(cursorRequest));
+ * }
+ * }</pre>
+ */
+public class CursorRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return CursorRequest.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        String cursor = webRequest.getParameter("cursor");
+        String sizeParam = webRequest.getParameter("size");
+
+        int size = parseOrDefault(sizeParam);
+
+        return CursorRequest.of(cursor, size);
+    }
+
+    private int parseOrDefault(String value) {
+        if (value == null) return PageRequest.DEFAULT_SIZE;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return PageRequest.DEFAULT_SIZE;
+        }
+    }
+}

--- a/src/main/java/com/followMe/common/pagination/CursorResponse.java
+++ b/src/main/java/com/followMe/common/pagination/CursorResponse.java
@@ -1,0 +1,58 @@
+package com.followMe.common.pagination;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * 커서 기반 페이지 응답 DTO.
+ *
+ * <p>{@code nextCursor}가 {@code null}이면 마지막 페이지입니다.
+ *
+ * <pre>{@code
+ * List<FeedEntity> feeds = feedRepository.findByCursor(cursor, size + 1);
+ * return CursorResponse.of(feeds, size, FeedResponse::from, FeedEntity::getCursorId);
+ * }</pre>
+ *
+ * @param <T> 콘텐츠 항목 타입
+ */
+@Getter
+public class CursorResponse<T> {
+
+    private final List<T> content;
+    private final String nextCursor; // null이면 마지막 페이지
+    private final boolean hasNext;
+
+    private CursorResponse(List<T> content, String nextCursor) {
+        this.content = content;
+        this.nextCursor = nextCursor;
+        this.hasNext = nextCursor != null;
+    }
+
+    // ── 팩토리 ────────────────────────────────────────────────────────────────
+
+    /**
+     * 엔티티 리스트 → DTO 리스트로 변환하며 다음 커서를 추출.
+     *
+     * <p>조회 시 {@code size + 1}개를 가져와서 다음 페이지 존재 여부를 판단합니다.
+     *
+     * @param entities     조회된 엔티티 목록 (size + 1개 조회 권장)
+     * @param size         요청 사이즈
+     * @param mapper       엔티티 → DTO 변환 함수
+     * @param cursorExtractor 다음 커서 값 추출 함수 (마지막 엔티티 기준)
+     */
+    public static <E, T> CursorResponse<T> of(List<E> entities, int size,
+                                               Function<E, T> mapper,
+                                               Function<E, String> cursorExtractor) {
+        boolean hasNext = entities.size() > size;
+        List<E> sliced = hasNext ? entities.subList(0, size) : entities;
+        String nextCursor = hasNext ? cursorExtractor.apply(sliced.get(sliced.size() - 1)) : null;
+        return new CursorResponse<>(sliced.stream().map(mapper).toList(), nextCursor);
+    }
+
+    /** 이미 변환된 DTO 리스트로 직접 생성. */
+    public static <T> CursorResponse<T> of(List<T> content, String nextCursor) {
+        return new CursorResponse<>(content, nextCursor);
+    }
+}

--- a/src/main/java/com/followMe/common/pagination/PageRequestArgumentResolver.java
+++ b/src/main/java/com/followMe/common/pagination/PageRequestArgumentResolver.java
@@ -1,0 +1,51 @@
+package com.followMe.common.pagination;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 컨트롤러 파라미터로 선언된 {@link PageRequest}를 쿼리 파라미터에서 자동 바인딩.
+ *
+ * <p>{@code ?page=0&size=10} 형태로 요청하면 {@link PageRequest}로 변환됩니다.
+ * 허용되지 않은 size 값은 {@link PageRequest#DEFAULT_SIZE}(10)으로 대체됩니다.
+ *
+ * <pre>{@code
+ * @GetMapping("/items")
+ * public ApiResponse<PageResponse<ItemResponse>> list(PageRequest pageRequest) {
+ *     return ApiResponse.success(itemService.list(pageRequest.toPageable()));
+ * }
+ * }</pre>
+ */
+public class PageRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return PageRequest.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        String pageParam = webRequest.getParameter("page");
+        String sizeParam = webRequest.getParameter("size");
+
+        int page = parseOrDefault(pageParam, 0);
+        int size = parseOrDefault(sizeParam, PageRequest.DEFAULT_SIZE);
+
+        return PageRequest.of(page, size);
+    }
+
+    private int parseOrDefault(String value, int defaultValue) {
+        if (value == null) return defaultValue;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}


### PR DESCRIPTION
📌 작업 설명
  - 오프셋 페이지네이션 규칙 강제화: PageRequestArgumentResolver 추가
  - 커서 페이지네이션 지원: CursorRequest / CursorResponse / CursorRequestArgumentResolver 추가

  ---
  🔍 작업 목적

- 페이지네이션 규칙 강제화
  페이지네이션 구현 과정에서 @RequestParam + PageRequest.of() 방식만으로는 허용 사이즈(10 / 30 / 50) 검증을 각 컨트롤러마다 직접 처리해야 하는 구조였음. 새 컨트롤러 추가 시 규칙이 누락될 위험이 있어, HandlerMethodArgumentResolver를 통해 공통화함.

- 커서 페이지네이션
  피드, 알림 등 무한 스크롤 형태의 API에서 오프셋 방식은 중복/누락 문제가 발생할 수 있어 커서 방식도 함께 지원함.

  ---
  ✅ 세부 작업 항목
  - PageRequestArgumentResolver 구현 및 CommonWebAutoConfiguration 자동 등록
  - CursorRequest 구현 (커서 + size 바인딩, 허용 size 검증 포함)
  - CursorResponse 구현 (nextCursor 자동 추출, hasNext 판단 포함)
  - CursorRequestArgumentResolver 구현 및 자동 등록

  ---
  📖 사용 가이드

  오프셋 페이지네이션

  요청
`  GET /items?page=0&size=10`

  컨트롤러
```java
@GetMapping("/items")
  public ApiResponse<PageResponse<ItemResponse>> list(PageRequest pageRequest) {
      Pageable pageable = pageRequest.toPageable();
      return ApiResponse.success(PageResponse.of(itemService.list(pageable), ItemResponse::from));
  }
``` 

  - page 미입력 시 기본값 0
  - size 미입력 또는 허용되지 않은 값(10/30/50 외)은 자동으로 10으로 대체`

  ---
  커서 페이지네이션

  요청
`  GET /feeds `         ← 첫 페이지 (cursor 없음)
`  GET /feeds?cursor=100&size=10 ` ← 다음 페이지

  컨트롤러
```java
 @GetMapping("/feeds")
  public ApiResponse<CursorResponse<FeedResponse>> list(CursorRequest cursorRequest) {
      return ApiResponse.success(feedService.list(cursorRequest));
  }
  ```


  서비스
```java
  public CursorResponse<FeedResponse> list(CursorRequest cursorRequest) {
      // size + 1개 조회 → 다음 페이지 존재 여부 판단
      List<FeedEntity> feeds = feedRepository.findByCursor(
          cursorRequest.getCursor(),
          cursorRequest.getSize() + 1
      );
      return CursorResponse.of(
          feeds,
          cursorRequest.getSize(),
          FeedResponse::from,
          feed -> String.valueOf(feed.getId())  // nextCursor 추출 기준
      );
  }
  ```
  레포지토리 쿼리 예시
```java
  @Query("SELECT f FROM Feed f WHERE (:cursor IS NULL OR f.id < :cursor) ORDER BY f.id DESC LIMIT :size")
  List<FeedEntity> findByCursor(@Param("cursor") String cursor, @Param("size") int size);        
  ```
                                                                                                                                                   
  응답 구조
```json 
{                                                                                                                                                
    "content": [...],
    "nextCursor": "95",  // null이면 마지막 페이지                                                                                                 
    "hasNext": true
  } 
  ```                                                                                                                                
   
