### PR TITLE
 [FIX] BaseTime, BaseAudit 인식 불가 문제 

### DIFF
--- a/src/main/java/com/followMe/common/entity/BaseAudit.java
+++ b/src/main/java/com/followMe/common/entity/BaseAudit.java
@@ -1,5 +1,7 @@
 package com.followMe.common.entity;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -25,6 +27,7 @@ import java.util.UUID;
  */
 @Getter
 @MappedSuperclass
+@Access(AccessType.FIELD)
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseAudit extends BaseTime {
 

--- a/src/main/java/com/followMe/common/entity/BaseTime.java
+++ b/src/main/java/com/followMe/common/entity/BaseTime.java
@@ -1,5 +1,7 @@
 package com.followMe.common.entity;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -23,6 +25,7 @@ import java.time.Instant;
  */
 @Getter
 @MappedSuperclass
+@Access(AccessType.FIELD)
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTime {
 


### PR DESCRIPTION
배경                                                                                                                                                                                                                             
                                                                                                                                                                                                                                   
  공통 모듈의 BaseTime, BaseAudit을 상속받는 도메인 서비스에서 QueryDSL 사용 시 감사 필드(createdAt, updatedAt 등)를 인식하지 못하는 에러가 발생했습니다.
                                                                                                                                                                                                                                   
  원인            
                                                                                                                                                                                                                                   
  @Access 설정이 없으면 JPA는 기본 접근 방식(property access, 즉 getter 기반)을 사용합니다. 도메인 서비스에서 QueryDSL APT가 공통 모듈 JAR의 @MappedSuperclass를 분석할 때 상속된 필드를 일관되게 인식하지 못해 Q 클래스에 감사    
  필드가 누락되는 문제가 생깁니다.
                                                                                                                                                                                                                                   
  변경 사항       

  - BaseTime, BaseAudit에 @Access(AccessType.FIELD) 추가                                                                                                                                                                           
    - JPA 필드 접근 방식을 field access로 명시적으로 고정
    - QueryDSL APT가 상속 계층의 필드를 안정적으로 인식할 수 있도록 보장                                                                                                                                                                                                                                                                                                                                                        
해당 공통 모듈 배포 후 도메인 서비스에서 QueryDSL을 사용하는 경우, 별도 코드 변경 없이 재빌드(APT 재실행)만으로 해결되어야함.   
안되면 다시 열어야 합니다!! (reopen)                                                                                      
