### PR TITLE
[FIX] BaseTime, BaseAudit 인식 실패 문제

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 // Spring Boot BOM을 version catalog로 관리 (소비자에게 강제하지 않음)
 val springBootVersion = "3.5.1"
 val lombokVersion = "1.18.34"
+val querydslVersion = "5.1.0"
 
 dependencies {
     // ── BOM (소비자에게 전이되지 않음, 라이브러리 컴파일용) ──────────────────
@@ -38,6 +39,11 @@ dependencies {
     compileOnly("jakarta.persistence:jakarta.persistence-api")
     compileOnly("org.springframework.data:spring-data-commons")
     compileOnly("org.springframework.data:spring-data-jpa")
+
+    // ── QueryDSL (Q 슈퍼타입 클래스 생성 — QBaseTime, QBaseAudit) ───────────
+    compileOnly("com.querydsl:querydsl-jpa:$querydslVersion:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:$querydslVersion:jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
     // ── Spring Web/MVC (GlobalExceptionHandler 용) ───────────────────────────
     compileOnly("org.springframework:spring-web")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     compileOnly("com.querydsl:querydsl-jpa:$querydslVersion:jakarta")
     annotationProcessor("com.querydsl:querydsl-apt:$querydslVersion:jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    api ("com.querydsl:querydsl-core:$querydslVersion")
 
     // ── Spring Web/MVC (GlobalExceptionHandler 용) ───────────────────────────
     compileOnly("org.springframework:spring-web")

--- a/src/main/java/com/followMe/common/entity/BaseAudit.java
+++ b/src/main/java/com/followMe/common/entity/BaseAudit.java
@@ -1,5 +1,6 @@
 package com.followMe.common.entity;
 
+import com.querydsl.core.annotations.QuerySupertype;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -26,6 +27,7 @@ import java.util.UUID;
  * }</pre>
  */
 @Getter
+@QuerySupertype
 @MappedSuperclass
 @Access(AccessType.FIELD)
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/followMe/common/entity/BaseTime.java
+++ b/src/main/java/com/followMe/common/entity/BaseTime.java
@@ -1,5 +1,6 @@
 package com.followMe.common.entity;
 
+import com.querydsl.core.annotations.QuerySupertype;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -24,6 +25,7 @@ import java.time.Instant;
  * }</pre>
  */
 @Getter
+@QuerySupertype
 @MappedSuperclass
 @Access(AccessType.FIELD)
 @EntityListeners(AuditingEntityListener.class)


### PR DESCRIPTION
문제: 
 QueryDSL로 BaseTime/BaseAudit 필드(createdAt, updatedAt 등)를
  Q 클래스 경로로 접근할 수 없었음.

해결 방법
@MappedSuperclass 에 대해 QueryDSL이 Q 슈퍼타입 클래스를 생성하기 위해 @QuerySupertype 어노테이션 추가
QueryDSL APT 의존성 자체을 위한  build.gradle.kts 추가
