### PR TITLE
[FEAT]event kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,42 +234,96 @@ boolean valid = TimeUtil.isBetween(Instant.now(), event.getStartAt(), event.getE
 
 ---
 
-### Kafka 이벤트
+### Kafka 이벤트 (Outbox 패턴)
 
 `spring-kafka` 의존성이 있는 서비스에서만 자동 활성화됩니다.
+트랜잭션 커밋 이후 Kafka 발행을 보장하며, 실패 시 자동 재시도합니다.
 
-이벤트 정의:
+#### 1. 메인 클래스 설정
+
+```java
+@EnableJpaAuditing
+@EnableScheduling   // OutboxRelayScheduler 동작에 필요
+@SpringBootApplication
+@EntityScan(basePackages = "com.followMe")  // 서비스 엔티티 + Outbox/Inbox 모두 스캔
+public class MyServiceApplication { ... }
+```
+
+#### 2. 이벤트 클래스 정의
+
+`BaseEvent`를 상속하고 `domainType`(어떤 도메인인지), `domainId`(대상 ID)를 생성자에서 지정합니다.
+`eventType`은 클래스명으로 자동 설정되며 Kafka 토픽명으로 사용됩니다.
 
 ```java
 @Getter
 public class OrderCreatedEvent extends BaseEvent {
-    private final UUID orderId;
-    private final UUID userId;
+    private final String customerName;
+    private final int totalPrice;
 
-    public OrderCreatedEvent(UUID orderId, UUID userId) {
-        super();
-        this.orderId = orderId;
-        this.userId = userId;
+    public OrderCreatedEvent(UUID orderId, String customerName, int totalPrice) {
+        super("ORDER", orderId);  // domainType, domainId(UUID 가능)
+        this.customerName = customerName;
+        this.totalPrice = totalPrice;
     }
 }
 ```
 
-발행:
+#### 3. 이벤트 발행
+
+`@Transactional` 안에서 `Events.trigger()`를 호출하세요.
+트랜잭션이 **커밋된 이후**에 Outbox DB 저장 → Kafka 발행이 순서대로 실행됩니다.
 
 ```java
 @Service
 @RequiredArgsConstructor
 public class OrderService {
-    private final KafkaEventPublisher eventPublisher;
 
-    public void createOrder(...) {
-        // ... 주문 생성 로직
-        eventPublisher.publish("order-events", new OrderCreatedEvent(order.getId(), userId));
+    @Transactional
+    public void createOrder(CreateOrderRequest request) {
+        Order order = orderRepository.save(Order.from(request));
+
+        Events.trigger(
+            new OrderCreatedEvent(order.getId(), request.getCustomerName(), order.getTotalPrice())
+                .withCorrelationId(request.getCorrelationId())  // 선택사항
+        );
     }
 }
 ```
 
-application.yml Kafka 직렬화 설정:
+> ⚠️ `@Transactional` 없이 호출하면 `OutboxEventListener`가 동작하지 않습니다.
+
+#### 4. 이벤트 소비 (중복 방지 포함)
+
+`InboxRepository`로 동일 이벤트가 중복 처리되는 것을 방지합니다.
+
+```java
+@Service
+@RequiredArgsConstructor
+public class NotificationConsumer {
+    private final InboxRepository inboxRepository;
+    private final NotificationService notificationService;
+
+    @Transactional
+    @KafkaListener(topics = "OrderCreatedEvent", groupId = "notification-service")
+    public void consume(OrderCreatedEvent event) {
+        UUID eventId = UUID.fromString(event.getEventId());
+
+        // 중복 처리 방지
+        if (inboxRepository.existsByIdAndMessageGroup(eventId, "OrderCreatedEvent")) {
+            return;
+        }
+
+        notificationService.sendOrderConfirmation(event);
+
+        inboxRepository.save(Inbox.builder()
+            .id(eventId)
+            .messageGroup("OrderCreatedEvent")
+            .build());
+    }
+}
+```
+
+#### 5. application.yml Kafka 설정
 
 ```yaml
 spring:
@@ -279,6 +333,19 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
         spring.json.add.type.headers: false
+```
+
+#### 동작 흐름
+
+```
+Events.trigger(event)
+  → ApplicationEventPublisher (Spring 내부)
+    → OutboxEventListener (트랜잭션 커밋 후)
+        ├── p_outbox 테이블에 PENDING 저장
+        └── Kafka 발행 → 성공: PROCESSED / 실패: FAILED
+              ↑
+OutboxRelayScheduler (10초마다)
+  └── PENDING/FAILED 중 재시도 3회 미만인 것 재발행
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ boolean valid = TimeUtil.isBetween(Instant.now(), event.getStartAt(), event.getE
 ```java
 @EnableJpaAuditing
 @EnableScheduling   // OutboxRelayScheduler 동작에 필요
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.followMe")
 @EntityScan(basePackages = "com.followMe")  // 서비스 엔티티 + Outbox/Inbox 모두 스캔
 public class MyServiceApplication { ... }
 ```

--- a/src/main/java/com/followMe/common/autoconfigure/CommonEventAutoConfiguration.java
+++ b/src/main/java/com/followMe/common/autoconfigure/CommonEventAutoConfiguration.java
@@ -1,0 +1,40 @@
+package com.followMe.common.autoconfigure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.followMe.common.event.Events;
+import com.followMe.common.event.outbox.OutboxEventListener;
+import com.followMe.common.event.outbox.OutboxRepository;
+import com.followMe.common.event.scheduler.OutboxRelayScheduler;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@AutoConfiguration
+@ConditionalOnClass(KafkaTemplate.class)
+public class CommonEventAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public Events events(ApplicationEventPublisher publisher) {
+    return new Events(publisher);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public OutboxEventListener outboxEventListener(
+      OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate,
+      ObjectMapper objectMapper) {
+    return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public OutboxRelayScheduler outboxRelayScheduler(
+      OutboxRepository outboxRepository, KafkaTemplate<String, Object> kafkaTemplate) {
+    return new OutboxRelayScheduler(outboxRepository, kafkaTemplate);
+  }
+}

--- a/src/main/java/com/followMe/common/event/BaseEvent.java
+++ b/src/main/java/com/followMe/common/event/BaseEvent.java
@@ -25,44 +25,43 @@ import lombok.Getter;
 @Getter
 public abstract class BaseEvent {
 
-    /** 이벤트 고유 ID (UUID) */
-    private final String eventId;
+  /** 이벤트 고유 ID (UUID) */
+  private final String eventId;
 
-    /** 이벤트 타입 (클래스 심플 네임) */
-    private final String eventType;
+  /** 이벤트 타입 (클래스 심플 네임) */
+  private final String eventType;
 
-    /** 이벤트 타입 (클래스 심플 네임) */
-    private final String domainType;
+  /** 도메인 타입 (Outbox 저장 및 파티션 키 계산용) */
+  private final String domainType;
 
-    /** 이벤트 타입 (클래스 심플 네임) */
-    private final String domainId;
+  /** 도메인 ID (Outbox 저장 및 파티션 키 계산용) */
+  private final String domainId;
 
-    /** 이벤트 발생 시각 (UTC) */
-    private final Instant occurredAt;
+  /** 이벤트 발생 시각 (UTC) */
+  private final Instant occurredAt;
 
-    /** 분산 추적용 Correlation ID (MDC 에서 자동 주입하거나 직접 설정) */
-    private String correlationId;
+  /** 분산 추적용 Correlation ID (MDC 에서 자동 주입하거나 직접 설정) */
+  private String correlationId;
 
+  protected BaseEvent(String domainType, UUID domainId) {
+    this(domainType, domainId == null ? null : domainId.toString());
+  }
 
+  protected BaseEvent(String domainType) {
+    this(domainType, (String) null);
+  }
 
-    protected BaseEvent(String domainType, UUID domainId) {
-        this(domainType, domainId.toString());
-    }
-    protected BaseEvent(String domainType) {
-        this(domainType, (String) null);
-    }
+  protected BaseEvent(String domainType, String domainId) {
+    this.domainType = domainType;
+    this.domainId = domainId;
+    this.eventId = UUID.randomUUID().toString();
+    this.eventType = this.getClass().getSimpleName();
+    this.occurredAt = Instant.now();
+  }
 
-    protected BaseEvent(String domainType, String domainId) {
-		this.domainType = domainType;
-		this.domainId = domainId;
-		this.eventId = UUID.randomUUID().toString();
-        this.eventType = this.getClass().getSimpleName();
-        this.occurredAt = Instant.now();
-    }
-
-    /** Correlation ID 를 직접 설정할 경우 사용 (MDC 연동 등) */
-    public BaseEvent withCorrelationId(String correlationId) {
-        this.correlationId = correlationId;
-        return this;
-    }
+  /** Correlation ID 를 직접 설정할 경우 사용 (MDC 연동 등) */
+  public BaseEvent withCorrelationId(String correlationId) {
+    this.correlationId = correlationId;
+    return this;
+  }
 }

--- a/src/main/java/com/followMe/common/event/BaseEvent.java
+++ b/src/main/java/com/followMe/common/event/BaseEvent.java
@@ -1,9 +1,8 @@
 package com.followMe.common.event;
 
-import lombok.Getter;
-
 import java.time.Instant;
 import java.util.UUID;
+import lombok.Getter;
 
 /**
  * Kafka 도메인 이벤트 기반 클래스.
@@ -32,24 +31,33 @@ public abstract class BaseEvent {
     /** 이벤트 타입 (클래스 심플 네임) */
     private final String eventType;
 
+    /** 이벤트 타입 (클래스 심플 네임) */
+    private final String domainType;
+
+    /** 이벤트 타입 (클래스 심플 네임) */
+    private final String domainId;
+
     /** 이벤트 발생 시각 (UTC) */
     private final Instant occurredAt;
 
     /** 분산 추적용 Correlation ID (MDC 에서 자동 주입하거나 직접 설정) */
     private String correlationId;
 
-    /** 이벤트 스키마 버전 (소비자 하위 호환성 관리용) */
-    private final int version;
 
-    protected BaseEvent() {
-        this(1);
+
+    protected BaseEvent(String domainType, UUID domainId) {
+        this(domainType, domainId.toString());
+    }
+    protected BaseEvent(String domainType) {
+        this(domainType, (String) null);
     }
 
-    protected BaseEvent(int version) {
-        this.eventId = UUID.randomUUID().toString();
+    protected BaseEvent(String domainType, String domainId) {
+		this.domainType = domainType;
+		this.domainId = domainId;
+		this.eventId = UUID.randomUUID().toString();
         this.eventType = this.getClass().getSimpleName();
         this.occurredAt = Instant.now();
-        this.version = version;
     }
 
     /** Correlation ID 를 직접 설정할 경우 사용 (MDC 연동 등) */

--- a/src/main/java/com/followMe/common/event/Events.java
+++ b/src/main/java/com/followMe/common/event/Events.java
@@ -1,6 +1,6 @@
 package com.followMe.common.event;
 
-import com.followMe.common.event.exception.EventPublishFailureEvent;
+import com.followMe.common.event.exception.EventPublishFailureException;
 import com.followMe.common.event.outbox.OutboxEvent;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class Events {
 
 	public static void trigger(BaseEvent event) {
 		if (publisher == null) {
-			throw new EventPublishFailureEvent("ApplicationEventPublisher is not initialized yet.");
+			throw new EventPublishFailureException("ApplicationEventPublisher is not initialized yet.");
 		}
 		publisher.publishEvent(new OutboxEvent(event));
 	}

--- a/src/main/java/com/followMe/common/event/Events.java
+++ b/src/main/java/com/followMe/common/event/Events.java
@@ -1,0 +1,27 @@
+package com.followMe.common.event;
+
+import com.followMe.common.event.exception.EventPublishFailureEvent;
+import com.followMe.common.event.outbox.OutboxEvent;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class Events {
+	private static ApplicationEventPublisher publisher;
+	private final ApplicationEventPublisher eventPublisher;
+
+	@PostConstruct
+	void init() {
+		Events.publisher = this.eventPublisher;
+	}
+
+	public static void trigger(BaseEvent event) {
+		if (publisher == null) {
+			throw new EventPublishFailureEvent("ApplicationEventPublisher is not initialized yet.");
+		}
+		publisher.publishEvent(new OutboxEvent(event));
+	}
+}

--- a/src/main/java/com/followMe/common/event/exception/EventPublishFailureEvent.java
+++ b/src/main/java/com/followMe/common/event/exception/EventPublishFailureEvent.java
@@ -1,0 +1,10 @@
+package com.followMe.common.event.exception;
+
+import com.followMe.common.exception.BusinessException;
+import com.followMe.common.exception.CommonErrorCode;
+
+public class EventPublishFailureEvent extends BusinessException {
+  public EventPublishFailureEvent(String message) {
+    super(CommonErrorCode.EVENT_PUBLISH_FAILURE, message);
+  }
+}

--- a/src/main/java/com/followMe/common/event/exception/EventPublishFailureException.java
+++ b/src/main/java/com/followMe/common/event/exception/EventPublishFailureException.java
@@ -3,8 +3,8 @@ package com.followMe.common.event.exception;
 import com.followMe.common.exception.BusinessException;
 import com.followMe.common.exception.CommonErrorCode;
 
-public class EventPublishFailureEvent extends BusinessException {
-  public EventPublishFailureEvent(String message) {
+public class EventPublishFailureException extends BusinessException {
+  public EventPublishFailureException(String message) {
     super(CommonErrorCode.EVENT_PUBLISH_FAILURE, message);
   }
 }

--- a/src/main/java/com/followMe/common/event/inbox/Inbox.java
+++ b/src/main/java/com/followMe/common/event/inbox/Inbox.java
@@ -1,0 +1,35 @@
+package com.followMe.common.event.inbox;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "p_inbox", indexes = {
+		@Index(name = "idx_inbox_message_group", columnList = "messageGroup"),
+		@Index(name = "idx_inbox_processed_at", columnList = "processedAt")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public class Inbox {
+
+	@Id
+	@Column(columnDefinition = "uuid")
+	private UUID id; // = 생산자의 eventId
+
+	@Column(length = 100)
+	private String messageGroup; // topic 또는 consumer group
+
+	@CreatedDate
+	@Column(updatable = false)
+	private Instant processedAt;
+}

--- a/src/main/java/com/followMe/common/event/inbox/InboxRepository.java
+++ b/src/main/java/com/followMe/common/event/inbox/InboxRepository.java
@@ -1,0 +1,9 @@
+package com.followMe.common.event.inbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface InboxRepository extends JpaRepository<Inbox, UUID> {
+	boolean existsByIdAndMessageGroup(UUID id, String messageGroup);
+}

--- a/src/main/java/com/followMe/common/event/outbox/Outbox.java
+++ b/src/main/java/com/followMe/common/event/outbox/Outbox.java
@@ -30,7 +30,7 @@ public class Outbox {
 	@Column(length = 50, nullable = false)
 	private String domainType;
 
-	@Column(length = 50, nullable = false)
+	@Column(length = 50)
 	private String domainId;
 
 	@Column(length = 100, nullable = false)

--- a/src/main/java/com/followMe/common/event/outbox/Outbox.java
+++ b/src/main/java/com/followMe/common/event/outbox/Outbox.java
@@ -1,0 +1,63 @@
+package com.followMe.common.event.outbox;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "p_outbox", indexes = @Index(name = "idx_outbox_status", columnList = "status"))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public class Outbox {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(length = 64, nullable = false, unique = true)
+	private String correlationId;
+
+	@Column(length = 50, nullable = false)
+	private String domainType;
+
+	@Column(length = 50, nullable = false)
+	private String domainId;
+
+	@Column(length = 100, nullable = false)
+	private String eventType;
+
+	@Column(columnDefinition = "text")
+	private String payload;
+
+	@Builder.Default
+	@Enumerated(EnumType.STRING)
+	@Column(length = 20, nullable = false)
+	private OutboxStatus status = OutboxStatus.PENDING;
+
+	@Builder.Default
+	private int retryCount = 0;
+
+	@CreatedDate
+	@Column(updatable = false)
+	private Instant createdAt;
+
+	public void complete() {
+		this.status = OutboxStatus.PROCESSED;
+	}
+
+	public void fail() {
+		this.status = OutboxStatus.FAILED;
+		this.retryCount++;
+	}
+
+}

--- a/src/main/java/com/followMe/common/event/outbox/OutboxEvent.java
+++ b/src/main/java/com/followMe/common/event/outbox/OutboxEvent.java
@@ -1,0 +1,11 @@
+package com.followMe.common.event.outbox;
+
+import com.followMe.common.event.BaseEvent;
+
+public record OutboxEvent(BaseEvent event) {
+	public String correlationId() {
+		String cid = event.getCorrelationId();
+		return cid != null ? cid : event.getEventId();
+	}
+
+}

--- a/src/main/java/com/followMe/common/event/outbox/OutboxEventListener.java
+++ b/src/main/java/com/followMe/common/event/outbox/OutboxEventListener.java
@@ -1,0 +1,51 @@
+package com.followMe.common.event.outbox;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.followMe.common.event.BaseEvent;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxEventListener {
+
+	private final OutboxRepository outboxRepository;
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private final ObjectMapper objectMapper;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handle(OutboxEvent outboxEvent) throws JsonProcessingException {
+		BaseEvent event = outboxEvent.event();
+
+		Outbox outbox = outboxRepository.save(Outbox.builder()
+				.correlationId(outboxEvent.correlationId())
+				.domainType(event.getDomainType())
+				.domainId(event.getDomainId())
+				.eventType(event.getEventType())
+				.payload(objectMapper.writeValueAsString(event))
+				.build());
+
+		UUID id = outbox.getId();
+		kafkaTemplate.send(event.getEventType(), event.getDomainId(), event)
+				.whenComplete((result, ex) -> updateStatus(id, ex == null));
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void updateStatus(UUID id, boolean success) {
+		outboxRepository.findById(id)
+				.ifPresent(outbox -> {
+					if (success) outbox.complete();
+					else outbox.fail();
+					outboxRepository.saveAndFlush(outbox);
+				});
+	}
+}

--- a/src/main/java/com/followMe/common/event/outbox/OutboxEventListener.java
+++ b/src/main/java/com/followMe/common/event/outbox/OutboxEventListener.java
@@ -20,32 +20,43 @@ public class OutboxEventListener {
 	private final OutboxRepository outboxRepository;
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 	private final ObjectMapper objectMapper;
+	private final OutboxStatusUpdater outboxStatusUpdater;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void handle(OutboxEvent outboxEvent) throws JsonProcessingException {
+	public void handle(OutboxEvent outboxEvent){
 		BaseEvent event = outboxEvent.event();
 
+		String payload;
+		try {
+			payload = objectMapper.writeValueAsString(event);
+		} catch (JsonProcessingException e) {
+			log.error(
+					"Failed to serialize event for Outbox. Marking as FAILED. eventType={}, domainType={}, domainId={}",
+					event.getEventType(),
+					event.getDomainType(),
+					event.getDomainId(),
+					e
+			);
+			Outbox failedOutbox = outboxRepository.save(Outbox.builder()
+					.correlationId(outboxEvent.correlationId())
+					.domainType(event.getDomainType())
+					.domainId(event.getDomainId())
+					.eventType(event.getEventType())
+					.payload(null)
+					.build());
+			outboxStatusUpdater.update(failedOutbox.getId(), false);
+			return;
+		}
 		Outbox outbox = outboxRepository.save(Outbox.builder()
 				.correlationId(outboxEvent.correlationId())
 				.domainType(event.getDomainType())
 				.domainId(event.getDomainId())
 				.eventType(event.getEventType())
-				.payload(objectMapper.writeValueAsString(event))
+				.payload(payload)
 				.build());
-
 		UUID id = outbox.getId();
-		kafkaTemplate.send(event.getEventType(), event.getDomainId(), event)
-				.whenComplete((result, ex) -> updateStatus(id, ex == null));
-	}
-
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void updateStatus(UUID id, boolean success) {
-		outboxRepository.findById(id)
-				.ifPresent(outbox -> {
-					if (success) outbox.complete();
-					else outbox.fail();
-					outboxRepository.saveAndFlush(outbox);
-				});
+		kafkaTemplate.send(event.getEventType(), event.getDomainId(), payload)
+				.whenComplete((result, ex) -> outboxStatusUpdater.update(id, ex == null));
 	}
 }

--- a/src/main/java/com/followMe/common/event/outbox/OutboxRepository.java
+++ b/src/main/java/com/followMe/common/event/outbox/OutboxRepository.java
@@ -1,0 +1,12 @@
+package com.followMe.common.event.outbox;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxRepository extends JpaRepository<Outbox, UUID> {
+  List<Outbox> findByStatusInAndRetryCountLessThan(List<OutboxStatus> statuses, int maxRetry);
+
+  Optional<Outbox> findByCorrelationId(String correlationId);
+}

--- a/src/main/java/com/followMe/common/event/outbox/OutboxStatus.java
+++ b/src/main/java/com/followMe/common/event/outbox/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.followMe.common.event.outbox;
+
+public enum OutboxStatus {
+  PENDING,
+  PROCESSED,
+  FAILED
+}

--- a/src/main/java/com/followMe/common/event/outbox/OutboxStatusUpdater.java
+++ b/src/main/java/com/followMe/common/event/outbox/OutboxStatusUpdater.java
@@ -1,0 +1,25 @@
+package com.followMe.common.event.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxStatusUpdater {
+
+	private final OutboxRepository outboxRepository;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void update(UUID id, boolean success) {
+		outboxRepository.findById(id).ifPresent(outbox -> {
+			if (success) outbox.complete();
+			else outbox.fail();
+			outboxRepository.saveAndFlush(outbox);
+		});
+	}
+
+}

--- a/src/main/java/com/followMe/common/event/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/followMe/common/event/scheduler/OutboxRelayScheduler.java
@@ -4,15 +4,14 @@ package com.followMe.common.event.scheduler;
 import com.followMe.common.event.outbox.Outbox;
 import com.followMe.common.event.outbox.OutboxRepository;
 import com.followMe.common.event.outbox.OutboxStatus;
+import com.followMe.common.event.outbox.OutboxStatusUpdater;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,12 +21,13 @@ public class OutboxRelayScheduler {
 
 	private final OutboxRepository outboxRepository;
 	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private final OutboxStatusUpdater outboxStatusUpdater;
 
 	@Scheduled(fixedDelay = 10_000)
 	@Transactional
 	public void relay() {
 		List<Outbox> targets =
-				outboxRepository.findByStatusInAndRetryCountLessThan(List.of(OutboxStatus.PENDING, OutboxStatus.FAILED),
+				outboxRepository.findByStatusInAndRetryCountLessThan(List.of(OutboxStatus.FAILED),
 						MAX_RETRY);
 
 		if (targets.isEmpty()) return;
@@ -37,23 +37,8 @@ public class OutboxRelayScheduler {
 		for (Outbox outbox : targets) {
 			UUID id = outbox.getId();
 			kafkaTemplate.send(outbox.getEventType(), outbox.getDomainId(), outbox.getPayload())
-					.whenComplete((result, ex) -> updateStatus(id, ex == null));
+					.whenComplete((result, ex) -> outboxStatusUpdater.update(id, ex == null));
 		}
 	}
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void updateStatus(UUID id, boolean success) {
-		outboxRepository.findById(id)
-				.ifPresent(outbox -> {
-					if (success) {
-						outbox.complete();
-						log.info("[Outbox] 재전송 성공: {}", outbox.getCorrelationId());
-					}
-					else {
-						outbox.fail();
-						log.warn("[Outbox] 재전송 실패 ({}회): {}", outbox.getRetryCount(), outbox.getCorrelationId());
-					}
-					outboxRepository.saveAndFlush(outbox);
-				});
-	}
 }

--- a/src/main/java/com/followMe/common/event/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/followMe/common/event/scheduler/OutboxRelayScheduler.java
@@ -1,0 +1,59 @@
+package com.followMe.common.event.scheduler;
+
+
+import com.followMe.common.event.outbox.Outbox;
+import com.followMe.common.event.outbox.OutboxRepository;
+import com.followMe.common.event.outbox.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxRelayScheduler {
+
+	private static final int MAX_RETRY = 3;
+
+	private final OutboxRepository outboxRepository;
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	@Scheduled(fixedDelay = 10_000)
+	@Transactional
+	public void relay() {
+		List<Outbox> targets =
+				outboxRepository.findByStatusInAndRetryCountLessThan(List.of(OutboxStatus.PENDING, OutboxStatus.FAILED),
+						MAX_RETRY);
+
+		if (targets.isEmpty()) return;
+
+		log.info("[Outbox] 재전송 대상 {}건", targets.size());
+
+		for (Outbox outbox : targets) {
+			UUID id = outbox.getId();
+			kafkaTemplate.send(outbox.getEventType(), outbox.getDomainId(), outbox.getPayload())
+					.whenComplete((result, ex) -> updateStatus(id, ex == null));
+		}
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void updateStatus(UUID id, boolean success) {
+		outboxRepository.findById(id)
+				.ifPresent(outbox -> {
+					if (success) {
+						outbox.complete();
+						log.info("[Outbox] 재전송 성공: {}", outbox.getCorrelationId());
+					}
+					else {
+						outbox.fail();
+						log.warn("[Outbox] 재전송 실패 ({}회): {}", outbox.getRetryCount(), outbox.getCorrelationId());
+					}
+					outboxRepository.saveAndFlush(outbox);
+				});
+	}
+}

--- a/src/main/java/com/followMe/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/followMe/common/exception/CommonErrorCode.java
@@ -24,7 +24,11 @@ public enum CommonErrorCode implements ErrorCode {
 
     // 5xx
     INTERNAL_SERVER_ERROR("C500", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    SERVICE_UNAVAILABLE("C503", "서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+    SERVICE_UNAVAILABLE("C503", "서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    EVENT_PUBLISH_FAILURE("C510", "이벤트 발행에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+
+    ;
+
 
     private final String code;
     private final String message;

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.followMe.common.autoconfigure.CommonWebAutoConfiguration
 com.followMe.common.autoconfigure.CommonKafkaAutoConfiguration
+com.followMe.common.autoconfigure.CommonEventAutoConfiguration


### PR DESCRIPTION

  ## 관련 이슈
  close #11 
  ## 개요
  기존 KafkaEventPublisher의 직접 발행 방식에서 Transactional Outbox 패턴으로 전환합니다.
  트랜잭션 커밋 이후에만 Kafka 발행을 보장하며, 실패 시 자동 재시도를 지원합니다.

  ## 변경 사항

  ### BaseEvent 개편
  - `domainType`, `domainId` 필드 추가 (Outbox 저장 및 Kafka 파티션 키로 활용)
  - `domainId` 없는 이벤트를 위한 옵셔널 생성자 추가
  - UUID 편의 생성자 추가
  - `version` 필드 제거

  ### Outbox 패턴 구현
  - `Outbox` 엔티티 (p_outbox 테이블) — 이벤트 발행 상태 추적
  - `OutboxEvent` 레코드 — Spring ApplicationEventPublisher용 봉투
  - `OutboxEventListener` — @TransactionalEventListener(AFTER_COMMIT)로 커밋 후 발행 보장
  - `OutboxRelayScheduler` — PENDING/FAILED 이벤트 10초마다 재시도 (최대 3회)

  ### Inbox 패턴 구현
  - `Inbox` 엔티티 (p_inbox 테이블) — 소비자 측 중복 처리 방지

  ### Events 정적 유틸
  - `Events.trigger()` — DDD 스타일 정적 발행 인터페이스
  - `EventPublishFailureEvent` — 발행 실패 시 예외 처리
  - `CommonEventAutoConfiguration` — 자동 빈 등록

  ### 문서
  - README.md 이벤트 사용법 전면 업데이트

  ## 소비자 서비스 적용 시 필요한 것
  - `@EnableScheduling` 추가
  - `@EntityScan(basePackages = "com.followMe")` 추가


