### PR TITLE
[FIX] event의 payload 문자열로 변형하지 않고 object로 전달

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind:2.19.1")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.1")
 
+    // ── Spring Boot Actuator (필수)
+    api("org.springframework.boot:spring-boot-starter-actuator")
+
     // ── Kafka (선택적 — 소비자가 spring-kafka 없으면 KafkaAutoConfig 비활성) ──
     compileOnly("org.springframework.kafka:spring-kafka")
 

--- a/src/main/java/com/followMe/common/autoconfigure/CommonEventAutoConfiguration.java
+++ b/src/main/java/com/followMe/common/autoconfigure/CommonEventAutoConfiguration.java
@@ -44,7 +44,8 @@ public class CommonEventAutoConfiguration {
   public OutboxRelayScheduler outboxRelayScheduler(
       OutboxRepository outboxRepository,
       KafkaTemplate<String, Object> kafkaTemplate,
-      OutboxStatusUpdater outboxStatusUpdater) {
-    return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
+      OutboxStatusUpdater outboxStatusUpdater,
+      ObjectMapper objectMapper) {
+    return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater, objectMapper);
   }
 }

--- a/src/main/java/com/followMe/common/event/outbox/OutboxEventListener.java
+++ b/src/main/java/com/followMe/common/event/outbox/OutboxEventListener.java
@@ -56,7 +56,7 @@ public class OutboxEventListener {
 				.payload(payload)
 				.build());
 		UUID id = outbox.getId();
-		kafkaTemplate.send(event.getEventType(), event.getDomainId(), payload)
+		kafkaTemplate.send(event.getEventType(), event.getDomainId(), event)
 				.whenComplete((result, ex) -> outboxStatusUpdater.update(id, ex == null));
 	}
 }

--- a/src/main/java/com/followMe/common/event/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/followMe/common/event/scheduler/OutboxRelayScheduler.java
@@ -1,6 +1,8 @@
 package com.followMe.common.event.scheduler;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.followMe.common.event.outbox.Outbox;
 import com.followMe.common.event.outbox.OutboxRepository;
 import com.followMe.common.event.outbox.OutboxStatus;
@@ -22,6 +24,7 @@ public class OutboxRelayScheduler {
 	private final OutboxRepository outboxRepository;
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 	private final OutboxStatusUpdater outboxStatusUpdater;
+	private final ObjectMapper objectMapper;
 
 	@Scheduled(fixedDelay = 10_000)
 	@Transactional
@@ -36,8 +39,14 @@ public class OutboxRelayScheduler {
 
 		for (Outbox outbox : targets) {
 			UUID id = outbox.getId();
-			kafkaTemplate.send(outbox.getEventType(), outbox.getDomainId(), outbox.getPayload())
-					.whenComplete((result, ex) -> outboxStatusUpdater.update(id, ex == null));
+			try {
+				Object payload = objectMapper.readValue(outbox.getPayload(), Object.class);
+				kafkaTemplate.send(outbox.getEventType(), outbox.getDomainId(), payload)
+						.whenComplete((result, ex) -> outboxStatusUpdater.update(id, ex == null));
+			} catch (JsonProcessingException e) {
+				log.error("[Outbox] 재전송 실패 - payload 파싱 오류. outboxId={}", id, e);
+				outboxStatusUpdater.update(id, false);
+			}
 		}
 	}
 


### PR DESCRIPTION
                                                                                     
  ## 관련 이슈
  closes #19          

## 개요                                                                                                        
  Kafka로 이벤트를 전송할 때 payload가 이중 직렬화되는 문제를 수정합니다.                                          
                                                                                                                   
  ## 문제
  - `OutboxEventListener`에서 이벤트를 저장할 때 payload를 JSON 문자열로 변환한 뒤,                                
    해당 문자열(String)을 그대로 Kafka로 전송하고 있었음                                                           
  - 결과적으로 Kafka consumer가 수신하는 메시지가 이중 직렬화된 상태(`"{\\"key\\":\\"value\\"}"`)가 됨             
                                                                                                                   
  ## 수정 내용                                                                                                     
                                                                                                                   
  ### OutboxEventListener                                                                                        
  - `kafkaTemplate.send()`에 직렬화된 `payload` 문자열 대신 원본 `event` 객체를 전달하도록 변경
                                                                                                                   
  ### OutboxRelayScheduler
  - DB에 저장된 payload 문자열을 `ObjectMapper`로 `Object`로 역직렬화한 뒤 Kafka로 전송                            
  - 파싱 실패 시 해당 outbox를 FAILED 처리하고 에러 로그 기록                                                      
  - `ObjectMapper` 의존성 주입 추가                                                                                
                                                                                                                   
  ### CommonEventAutoConfiguration                                                                                 
  - `OutboxRelayScheduler` 빈 생성 시 `ObjectMapper` 주입 추가                                                     
                                                                                                                   
  ### build.gradle.kts                                                                                           
  - `spring-boot-starter-actuator` 의존성 추가
                                                